### PR TITLE
perf(css): remove cjk and sans/serif fonts and use async css hacks

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -28,6 +28,8 @@ const {
 } = Astro.props;
 
 const socialImageURL = new URL(ogImage, Astro.url.origin).href;
+const webFont =
+  "https://fonts.googleapis.com/css2?family=Noto+Color+Emoji&family=Noto+Sans+Mono:wght@100..900&display=swap";
 ---
 
 <!doctype html>
@@ -101,9 +103,15 @@ const socialImageURL = new URL(ogImage, Astro.url.origin).href;
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      href="https://fonts.googleapis.com/css2?family=Noto+Color+Emoji&family=Noto+Sans+Mono:wght@100..900&family=Noto+Sans+SC:wght@100..900&family=Noto+Sans:ital,wght@0,100..900;1,100..900&family=Noto+Serif+SC:wght@200;300;400;500;600;700;900&family=Noto+Serif:ital,wght@0,100..900;1,100..900&display=swap"
       rel="stylesheet"
+      href={webFont}
+      media="print"
+      onload="this.onload=null;this.removeAttribute('media');"
+      fetchpriority="high"
     />
+    <noscript>
+      <link rel="stylesheet" href={webFont} />
+    </noscript>
 
     {
       // If PUBLIC_GOOGLE_SITE_VERIFICATION is set in the environment variable,

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -3,12 +3,6 @@ import { fontFamily } from "tailwindcss/defaultTheme";
 import typography from "@tailwindcss/typography";
 import scrollbar from "tailwind-scrollbar";
 
-const 
-sans= ["Noto Sans", "Noto Sans SC", "Noto Color Emoji", ...fontFamily.sans],
-serif= ["Noto Serif", "Noto Serif SC", "Noto Color Emoji", ...fontFamily.serif],
-mono= ["Noto Sans Mono", "Noto Sans SC", "Noto Color Emoji", ...fontFamily.mono],
-skin = mono;
-
 export default {
   content: ["./src/**/*.{astro,html,js,jsx,md,mdx,svelte,ts,tsx,vue}", "./astro.config.ts"],
   theme: {
@@ -64,10 +58,7 @@ export default {
         transparent: "transparent",
       },
       fontFamily: {
-        skin,
-				sans,
-				serif,
-        mono,
+        skin: ["Noto Sans Mono", "Noto Color Emoji", ...fontFamily.mono],
       },
       typography: {
         DEFAULT: {


### PR DESCRIPTION
Remove CJK and Sans/Serif fonts from Layout.astro. Use async css swapping hacks from https://pagespeedchecklist.com/asynchronous-google-fonts.